### PR TITLE
Compression fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Here is a list of ones that work and don't work thus far from personal testing. 
 ~~is installed and in <code>C:/Program Files/</code>, the PDF files will be automatically compressed (40MB -> 250KB!). The standard~~
 ~~installer package to grab is <code>qpdf-11.1.1-mingw64.exe</code> for Windows 10 users.~~
 
-Resolved using pikepdf, a Python library based on QPDF. If compression succeeds, you should have a PDF document ending with ".compressed.pdf".
-If compression fails for any reason, you should still have your PDF file, but still with the large file size due to layer stacking.
+Resolved using pikepdf, a Python library based on QPDF. If compression fails for any reason, you should still have your PDF file, but still with the large file size due to layer stacking and get a message alerting you that it failed to compress.
 
 <p align='center'><img src="https://user-images.githubusercontent.com/32918812/197358506-e0b39fd4-befa-40a2-a122-022473fdabdb.png" alt="gunBack" /></p>
 <p align='center'>Fig 4. Compression gained by QPDF.</p>

--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ Here is a list of ones that work and don't work thus far from personal testing. 
 <b>Untested</b>: Slim Reader, Nitro Reader, PDF Viewer Pro, Xodo PDF Reader, ...
 
 ## PDF Filesize + Compression
-By default the size of the output PDFs will be rather large (e.g. 40MB). This is due to how layer stacking is performed
-in the PDF graph. No pure-Python libraries have the ability to perform compression with annotation and most external
-programs are unable to preserve annotations.
+~~By default the size of the output PDFs will be rather large (e.g. 40MB). This is due to how layer stacking is performed~~
+~~in the PDF graph. No pure-Python libraries have the ability to perform compression with annotation and most external~~
+~~programs are unable to preserve annotations.~~
 
-However I found that QPDF (https://github.com/qpdf/qpdf/releases/tag/v11.1.1) is able to do this. As such, if QPDF 11.1.1
-is installed and in <code>C:/Program Files/</code>, the PDF files will be automatically compressed (40MB -> 250KB!). The standard
-installer package to grab is <code>qpdf-11.1.1-mingw64.exe</code> for Windows 10 users.
+~~However I found that QPDF (https://github.com/qpdf/qpdf/releases/tag/v11.1.1) is able to do this. As such, if QPDF 11.1.1~~
+~~is installed and in <code>C:/Program Files/</code>, the PDF files will be automatically compressed (40MB -> 250KB!). The standard~~
+~~installer package to grab is <code>qpdf-11.1.1-mingw64.exe</code> for Windows 10 users.~~
+
+Resolved using pikepdf, a Python library based on QPDF. If compression succeeds, you should have a PDF document ending with ".compressed.pdf".
+If compression fails for any reason, you should still have your PDF file, but still with the large file size due to layer stacking.
 
 <p align='center'><img src="https://user-images.githubusercontent.com/32918812/197358506-e0b39fd4-befa-40a2-a122-022473fdabdb.png" alt="gunBack" /></p>
 <p align='center'>Fig 4. Compression gained by QPDF.</p>

--- a/README.md
+++ b/README.md
@@ -28,18 +28,13 @@ Here is a list of ones that work and don't work thus far from personal testing. 
 <b>Untested</b>: Slim Reader, Nitro Reader, PDF Viewer Pro, Xodo PDF Reader, ...
 
 ## PDF Filesize + Compression
-~~By default the size of the output PDFs will be rather large (e.g. 40MB). This is due to how layer stacking is performed~~
-~~in the PDF graph. No pure-Python libraries have the ability to perform compression with annotation and most external~~
-~~programs are unable to preserve annotations.~~
+The default size of the output Gun PDFs will be rather large (e.g., 40MB). This is due to how layer stacking is performed in the PDF graph.
+We resolve this using the Python library pikepdf, based on the application QPDF. Compression is done automatically when generating.
 
-~~However I found that QPDF (https://github.com/qpdf/qpdf/releases/tag/v11.1.1) is able to do this. As such, if QPDF 11.1.1~~
-~~is installed and in <code>C:/Program Files/</code>, the PDF files will be automatically compressed (40MB -> 250KB!). The standard~~
-~~installer package to grab is <code>qpdf-11.1.1-mingw64.exe</code> for Windows 10 users.~~
-
-Resolved using pikepdf, a Python library based on QPDF. If compression fails for any reason, you should still have your PDF file, but still with the large file size due to layer stacking and get a message alerting you that it failed to compress.
+If compression fails for any reason, the original (large size) PDF should still exist in your outputs folder. A message will alert you stating that pikepdf failed to compress.
 
 <p align='center'><img src="https://user-images.githubusercontent.com/32918812/197358506-e0b39fd4-befa-40a2-a122-022473fdabdb.png" alt="gunBack" /></p>
-<p align='center'>Fig 4. Compression gained by QPDF.</p>
+<p align='center'>Fig 4. Compression gained by pikepdf/QPDF.</p>
 
 ## FoundryVTT Support
 This LootGenerator has support for outputting files to import into Eronth's 

--- a/classes/GunPDF.py
+++ b/classes/GunPDF.py
@@ -490,14 +490,10 @@ class GunPDF:
                 position = {'page': 1, 'x0': 445, 'y0': 360, 'x1': 495, 'y1': 390}
                 self.add_image_to_pdf(output_path, f"{self.base_dir}resources/images/element_icons/{self.element_icon_paths.get(gun.element[2], 'PLACEHOLDER.PNG')}", position)
 
-        # Try PDF Compression via QPDF. Requires user install to function.
+        # Try PDF Compression via pikepdf
         self.compressPDF(output_path)
-        # if os.path.exists('C:/Program Files/qpdf 11.1.1/bin/qpdf.exe'):
-        #     os.system(f'C:\\"Program Files"\\"qpdf 11.1.1"\\bin\\qpdf.exe --no-warn --flatten-annotations=all "{output_path}" "{output_path[:-4]}.compressed.pdf"')
-        #     if os.path.exists(f"{output_path[:-4]}.compressed.pdf"):
-        #         os.remove(f"{output_path}")
-        #         os.rename(f"{output_path[:-4]}.compressed.pdf", f"{output_path[:-4]}.pdf")
     
+    #PDF compression method using pikepdf, a Python tool based on QPDF
     def compressPDF(self, output_path):
         try:
             with pikepdf.open(output_path) as pdf:

--- a/classes/GunPDF.py
+++ b/classes/GunPDF.py
@@ -495,6 +495,7 @@ class GunPDF:
                 pdf.flatten_annotations('all')
                 pdf.save(f"{output_path[:-4]}.compressed.pdf")
                 os.remove(f"{output_path}")
+                os.rename(f"{output_path[:-4]}.compressed.pdf", f"{output_path[:-4]}.pdf")
         except Exception:
             self.statusbar.clearMessage()
             self.statusbar.showMessage("Failed to compress the PDF!", 5000)

--- a/classes/GunPDF.py
+++ b/classes/GunPDF.py
@@ -8,6 +8,7 @@ import os
 import fitz
 import pdfrw
 import requests
+import pikepdf
 
 from PIL import Image
 
@@ -337,11 +338,12 @@ class GunPDF:
                 self.add_image_to_pdf(output_path, f"{self.base_dir}resources/images/element_icons/{self.element_icon_paths.get(gun.element[2], 'PLACEHOLDER.PNG')}", position)
 
         # Try PDF Compression via QPDF. Requires user install to function.
-        if os.path.exists('C:/Program Files/qpdf 11.1.1/bin/qpdf.exe'):
-            os.system(f'C:\\"Program Files"\\"qpdf 11.1.1"\\bin\\qpdf.exe --no-warn --flatten-annotations=all "{output_path}" "{output_path[:-4]}.compressed.pdf"')
-            if os.path.exists(f"{output_path[:-4]}.compressed.pdf"):
-                os.remove(f"{output_path}")
-                os.rename(f"{output_path[:-4]}.compressed.pdf", f"{output_path[:-4]}.pdf")
+        self.compressPDF(output_path)
+        # if os.path.exists('C:/Program Files/qpdf 11.1.1/bin/qpdf.exe'):
+        #     os.system(f'C:\\"Program Files"\\"qpdf 11.1.1"\\bin\\qpdf.exe --no-warn --flatten-annotations=all "{output_path}" "{output_path[:-4]}.compressed.pdf"')
+        #     if os.path.exists(f"{output_path[:-4]}.compressed.pdf"):
+        #         os.remove(f"{output_path}")
+        #         os.rename(f"{output_path[:-4]}.compressed.pdf", f"{output_path[:-4]}.pdf")
 
     def generate_split_gun_pdf(self, output_name, gun, rarity_border, form_check, redtext_check):
         """
@@ -489,8 +491,19 @@ class GunPDF:
                 self.add_image_to_pdf(output_path, f"{self.base_dir}resources/images/element_icons/{self.element_icon_paths.get(gun.element[2], 'PLACEHOLDER.PNG')}", position)
 
         # Try PDF Compression via QPDF. Requires user install to function.
-        if os.path.exists('C:/Program Files/qpdf 11.1.1/bin/qpdf.exe'):
-            os.system(f'C:\\"Program Files"\\"qpdf 11.1.1"\\bin\\qpdf.exe --no-warn --flatten-annotations=all "{output_path}" "{output_path[:-4]}.compressed.pdf"')
-            if os.path.exists(f"{output_path[:-4]}.compressed.pdf"):
+        self.compressPDF(output_path)
+        # if os.path.exists('C:/Program Files/qpdf 11.1.1/bin/qpdf.exe'):
+        #     os.system(f'C:\\"Program Files"\\"qpdf 11.1.1"\\bin\\qpdf.exe --no-warn --flatten-annotations=all "{output_path}" "{output_path[:-4]}.compressed.pdf"')
+        #     if os.path.exists(f"{output_path[:-4]}.compressed.pdf"):
+        #         os.remove(f"{output_path}")
+        #         os.rename(f"{output_path[:-4]}.compressed.pdf", f"{output_path[:-4]}.pdf")
+    
+    def compressPDF(self, output_path):
+        try:
+            with pikepdf.open(output_path) as pdf:
+                pdf.flatten_annotations('all')
+                pdf.save(f"{output_path[:-4]}.compressed.pdf")
                 os.remove(f"{output_path}")
-                os.rename(f"{output_path[:-4]}.compressed.pdf", f"{output_path[:-4]}.pdf")
+        except Exception:
+            self.statusbar.clearMessage()
+            self.statusbar.showMessage("Failed to compress the PDF!", 5000)

--- a/classes/GunPDF.py
+++ b/classes/GunPDF.py
@@ -337,13 +337,8 @@ class GunPDF:
                 position = {'page': 1, 'x0': 60, 'y0': 500, 'x1': 110, 'y1': 530}
                 self.add_image_to_pdf(output_path, f"{self.base_dir}resources/images/element_icons/{self.element_icon_paths.get(gun.element[2], 'PLACEHOLDER.PNG')}", position)
 
-        # Try PDF Compression via QPDF. Requires user install to function.
+        # Try PDF Compression via pikepdf
         self.compressPDF(output_path)
-        # if os.path.exists('C:/Program Files/qpdf 11.1.1/bin/qpdf.exe'):
-        #     os.system(f'C:\\"Program Files"\\"qpdf 11.1.1"\\bin\\qpdf.exe --no-warn --flatten-annotations=all "{output_path}" "{output_path[:-4]}.compressed.pdf"')
-        #     if os.path.exists(f"{output_path[:-4]}.compressed.pdf"):
-        #         os.remove(f"{output_path}")
-        #         os.rename(f"{output_path[:-4]}.compressed.pdf", f"{output_path[:-4]}.pdf")
 
     def generate_split_gun_pdf(self, output_name, gun, rarity_border, form_check, redtext_check):
         """


### PR DESCRIPTION
Updated the project to use pikepdf library instead of relying on absolute file path search of an application.
Fix created to resolve compression issue on Linux machines that do not have the same file structure and the application was restricted to a specific version of QPDF.

Please see if this works for your machine, as I had to update from PyQt5 to PyQt6 to properly run the application on my computer and I am still working on resolving the PDF viewer to hopefully have that work on my linux machine as well.